### PR TITLE
Add support for globals, C++, "exporting" functions to AHK

### DIFF
--- a/Examples/C++_with_new_delete.ahk
+++ b/Examples/C++_with_new_delete.ahk
@@ -4,21 +4,7 @@
 CPP = 
 ( %
 
-#include <stdint.h>
-
-typedef uint64_t size_t;
-
-void* (*HeapAlloc)(uint64_t, uint32_t, size_t);
-void (*HeapFree)(uint64_t, uint32_t, void*);
-
-uint64_t hProcessHeap;
-
-void* operator new(size_t size) {
-	return HeapAlloc(hProcessHeap, 0x8, size);
-}
-void operator delete(void* Memory) {
-	HeapFree(hProcessHeap, 0, Memory);
-}
+#include "ahk.h"
 
 class Point {
 public:

--- a/Examples/C++_with_new_delete.ahk
+++ b/Examples/C++_with_new_delete.ahk
@@ -1,0 +1,45 @@
+#Include %A_ScriptDir%/../
+#include MCLib.ahk
+
+CPP = 
+( %
+
+#include <stdint.h>
+
+typedef uint64_t size_t;
+
+void* (*HeapAlloc)(uint64_t, uint32_t, size_t);
+void (*HeapFree)(uint64_t, uint32_t, void*);
+
+uint64_t hProcessHeap;
+
+void* operator new(size_t size) {
+	return HeapAlloc(hProcessHeap, 0x8, size);
+}
+void operator delete(void* Memory) {
+	HeapFree(hProcessHeap, 0, Memory);
+}
+
+class Point {
+public:
+	Point(int NX, int NY) {
+		X = NX;
+		Y = NY;
+	}
+
+private:
+	int X;
+	int Y;
+};
+
+Point* __main(int X, int Y) {
+	return new Point(X, Y);
+}
+
+)
+
+pCode := MCLib.FromCPP(CPP)
+
+pPoint := DllCall(pCode, "Int", 20, "Int", 30, "Ptr")
+
+MsgBox, % NumGet(pPoint+0, 0, "Int") ", " NumGet(pPoint+0, 4, "Int")

--- a/Examples/C_as_library.ahk
+++ b/Examples/C_as_library.ahk
@@ -1,0 +1,26 @@
+#Include %A_ScriptDir%/../
+#include MCLib.ahk
+
+C =
+( %
+
+#define MCODE_LIBRARY
+#include "ahk.h"
+
+MCODE_EXPORT_INLINE(int, Add, (int Left, int Right)) {
+    return Left + Right;
+}
+
+MCODE_EXPORT_INLINE(int, Multiply, (int Left, int Right)) {
+    return Left * Right;
+}
+
+)
+
+Code := MCLib.FromC(C)
+
+Added := DllCall(Code.Add, "Int", 300, "Int", -20, "Int")
+MsgBox, % Added
+
+Multiplied := DllCall(Code.Multiply, "Int", Added, "Int", 2, "Int")
+MsgBox, % Multiplied

--- a/Examples/C_export_to_ahk.ahk
+++ b/Examples/C_export_to_ahk.ahk
@@ -1,0 +1,31 @@
+#Include %A_ScriptDir%/../
+#include MCLib.ahk
+
+C =
+( %
+
+#include "ahk.h"
+
+typedef struct {
+	int X;
+	int Y;
+} Point;
+
+Point* __main(int a, int b) {
+	Point* P = malloc(sizeof(Point));
+	
+	P->X = a;
+	P->Y = b;
+	
+	return P;
+}
+
+)
+
+Code := MCLib.AHKFromC(C, false) ; Compile and stringify the code, but don't format it as an AHK string literal (since we're going to load it again momentarily)
+
+pCode := MCLib.FromString(Code)
+
+pPoint := DllCall(pCode, "Int", 20, "Int", 30, "Ptr")
+
+MsgBox, % NumGet(pPoint+0, 0, "Int") ", " NumGet(pPoint+0, 4, "Int")

--- a/Examples/C_with_floats.ahk
+++ b/Examples/C_with_floats.ahk
@@ -1,0 +1,15 @@
+#Include %A_ScriptDir%/../
+#include MCLib.ahk
+
+C =
+( %
+
+double __main(double In) {
+	return In * 2.5;
+}
+
+)
+
+pCode := MCLib.FromC(C)
+
+MsgBox, % DllCall(pCode, "Double", 11.7, "Double")

--- a/Examples/C_with_globals.ahk
+++ b/Examples/C_with_globals.ahk
@@ -1,0 +1,24 @@
+#Include %A_ScriptDir%/../
+#include MCLib.ahk
+
+C =
+( %
+
+int SavedValue = 10;
+
+int __main(int NewValue) {
+	int Result = SavedValue;
+	
+	SavedValue = NewValue;
+	
+	return Result;
+}
+
+)
+
+pCode := MCLib.FromC(C)
+
+MsgBox, % DllCall(pCode, "Int", 20, "Ptr")
+MsgBox, % DllCall(pCode, "Int", 30, "Ptr")
+MsgBox, % DllCall(pCode, "Int", 40, "Ptr")
+MsgBox, % DllCall(pCode, "Int", 50, "Ptr")

--- a/Examples/C_with_memory_allocation.ahk
+++ b/Examples/C_with_memory_allocation.ahk
@@ -4,22 +4,7 @@
 C =
 ( %
 
-#include <stdint.h>
-
-typedef uint64_t size_t;
-
-void* (*HeapAlloc)(uint64_t, uint32_t, size_t);
-void (*HeapFree)(uint64_t, uint32_t, void*);
-
-uint64_t hProcessHeap;
-
-void* malloc(size_t Size) {
-	return HeapAlloc(hProcessHeap, 0x8, Size);
-}
-void free(void* Memory) {
-	HeapFree(hProcessHeap, 0, Memory);
-}
-
+#include "ahk.h"
 
 typedef struct {
 	int X;

--- a/Examples/C_with_memory_allocation.ahk
+++ b/Examples/C_with_memory_allocation.ahk
@@ -1,0 +1,44 @@
+#Include %A_ScriptDir%/../
+#include MCLib.ahk
+
+C =
+( %
+
+#include <stdint.h>
+
+typedef uint64_t size_t;
+
+void* (*HeapAlloc)(uint64_t, uint32_t, size_t);
+void (*HeapFree)(uint64_t, uint32_t, void*);
+
+uint64_t hProcessHeap;
+
+void* malloc(size_t Size) {
+	return HeapAlloc(hProcessHeap, 0x8, Size);
+}
+void free(void* Memory) {
+	HeapFree(hProcessHeap, 0, Memory);
+}
+
+
+typedef struct {
+	int X;
+	int Y;
+} Point;
+
+Point* __main(int a, int b) {
+	Point* P = malloc(sizeof(Point));
+	
+	P->X = a;
+	P->Y = b;
+	
+	return P;
+}
+
+)
+
+pCode := MCLib.FromC(C)
+
+pPoint := DllCall(pCode, "Int", 20, "Int", 30, "Ptr")
+
+MsgBox, % NumGet(pPoint+0, 0, "Int") ", " NumGet(pPoint+0, 4, "Int")

--- a/MCLib.ahk
+++ b/MCLib.ahk
@@ -1,7 +1,64 @@
 ﻿#Include SymbolReader.ahk
 
 class MClib {
-	Generic(Compiler, Code, ExtraOptions := "") {
+	class LZ {
+		Compress(pData, cbData, pCData, cbCData)
+		{
+			if (r := DllCall("ntdll\RtlGetCompressionWorkSpaceSize"
+				, "UShort", 0x102                        ; USHORT CompressionFormatAndEngine
+				, "UInt*", compressBufferWorkSpaceSize   ; PULONG CompressBufferWorkSpaceSize
+				, "UInt*", compressFragmentWorkSpaceSize ; PULONG CompressFragmentWorkSpaceSize
+				, "UInt")) ; NTSTATUS
+				throw Exception("Erorr calling RtlGetCompressionWorkSpaceSize",, Format("0x{:08x}", r))
+			
+			VarSetCapacity(compressBufferWorkSpace, compressBufferWorkSpaceSize)
+			
+			if (r := DllCall("ntdll\RtlCompressBuffer"
+				, "UShort", 0x102                       ; USHORT CompressionFormatAndEngine,
+				, "Ptr", pData                          ; PUCHAR UncompressedBuffer,
+				, "UInt", cbData                        ; ULONG  UncompressedBufferSize,
+				, "Ptr", pCData                         ; PUCHAR CompressedBuffer,
+				, "UInt", cbCData                       ; ULONG  CompressedBufferSize,
+				, "UInt", compressFragmentWorkSpaceSize ; ULONG  UncompressedChunkSize,
+				, "UInt*", finalCompressedSize          ; PULONG FinalCompressedSize,
+				, "Ptr", &compressBufferWorkSpace       ; PVOID  WorkSpace
+				, "UInt")) ; NTSTATUS
+				throw Exception("Error calling RtlCompressBuffer",, Format("0x{:08x}", r))
+			
+			return finalCompressedSize
+		}
+
+		Decompress(pCData, cbCData, pData, cbData)
+		{
+			if (r := DllCall("ntdll\RtlDecompressBuffer"
+				, "UShort",  0x102 ; USHORT CompressionFormat
+				, "Ptr", pData     ; PUCHAR UncompressedBuffer
+				, "UInt", cbData   ; ULONG  UncompressedBufferSize
+				, "Ptr", pCData    ; PUCHAR CompressedBuffer
+				, "UInt", cbCData  ; ULONG  CompressedBufferSize,
+				, "UInt*", cbFinal ; PULONG FinalUncompressedSize
+				, "UInt")) ; NTSTATUS
+				throw Exception("Error calling RtlDecompressBuffer",, Format("0x{:08x}", r))
+			
+			return cbFinal
+		}
+	}
+
+	NormalizeSymbols(Symbols) {
+		KeepSymbolNames := {"__main": 1, "hProcessHeap": 1, "HeapAlloc": 1, "HeapFree": 1}
+
+		Result := {}
+
+		for SymbolName, Symbol in Symbols {
+			if (KeepSymbolNames[SymbolName] || RegExMatch(SymbolName, "O)__mcode_e_(\w+)")) {
+				Result[SymbolName] := Symbol.Value
+			}
+		}
+
+		return Result
+	}
+
+	Compile(Compiler, Code, ExtraOptions := "") {
 		OldWorkingDir := A_WorkingDir
 		SetWorkingDir, %A_LineFile%/../
 
@@ -47,19 +104,19 @@ class MClib {
 
 		SetWorkingDir, % OldWorkingDir
 
-		return [pCode, Output]
+		return [pCode, Output.SectionsByName[".text"].FileSize, this.NormalizeSymbols(Output.AbsoluteSymbols)]
 	}
 	
-	Fixup(pCode, Output) {
+	Load(pCode, CodeSize, Symbols) {
 		static hKernel32    := DllCall("GetModuleHandle", "Str", "kernel32", "Ptr")
 		static hProcessHeap := DllCall("GetProcessHeap", "Ptr")
 		static HeapAlloc    := DllCall("GetProcAddress", "Ptr", hKernel32, "AStr", "HeapAlloc", "Ptr")
 		static HeapFree     := DllCall("GetProcAddress", "Ptr", hKernel32, "AStr", "HeapFree", "Ptr")
 		
-		OffsetOfhProcessHeap := Output.AbsoluteSymbols["hProcessHeap"].Value
-		OffsetOfHeapAlloc    := Output.AbsoluteSymbols["HeapAlloc"].Value
-		OffsetOfHeapFree     := Output.AbsoluteSymbols["HeapFree"].Value
-		OffsetOfMain         := Output.AbsoluteSymbols["__main"].Value
+		OffsetOfhProcessHeap := Symbols["hProcessHeap"]
+		OffsetOfHeapAlloc    := Symbols["HeapAlloc"]
+		OffsetOfHeapFree     := Symbols["HeapFree"]
+		OffsetOfMain         := Symbols["__main"]
 		
 		if (OffsetOfhProcessHeap && OffsetOfHeapAlloc && OffsetOfHeapFree) {
 			NumPut(hProcessHeap, pCode + 0, OffsetOfhProcessHeap, "Ptr")
@@ -67,16 +124,14 @@ class MClib {
 			NumPut(HeapFree    , pCode + 0, OffsetOfHeapFree    , "Ptr")
 		}
 		
-		TextSize := Output.SectionsByName[".text"].FileSize
-		
-		if !DllCall("VirtualProtect", "Ptr", pCode, "Ptr", TextSize, "UInt", 0x40, "UInt*", OldProtect, "UInt")
+		if !DllCall("VirtualProtect", "Ptr", pCode, "Ptr", CodeSize, "UInt", 0x40, "UInt*", OldProtect, "UInt")
 			Throw Exception("Failed to mark MCLib memory as executable")
 		
 		Exports := {}
 
-		for SymbolName, Symbol in Output.AbsoluteSymbols {
+		for SymbolName, SymbolOffset in Symbols {
 			if (RegExMatch(SymbolName, "O)__mcode_e_(\w+)", Match)) {
-				Exports[Match[1]] := pCode + Symbol.Value
+				Exports[Match[1]] := pCode + SymbolOffset
 			}
 		}
 
@@ -89,24 +144,25 @@ class MClib {
 	}
 	
 	FromC(Code) {
-		return this.Fixup(this.Generic("gcc", Code)*)
+		return this.Load(this.Compile("gcc", Code)*)
 	}
 	
 	FromCPP(Code) {
-		return this.Fixup(this.Generic("g++", "extern ""C"" {`n" Code "`n}", " -fno-exceptions -fno-rtti")*)
+		return this.Load(this.Compile("g++", "extern ""C"" {`n" Code "`n}", " -fno-exceptions -fno-rtti")*)
 	}
 	
-	Pack(pCode, Output) {
-		if (Output.AbsoluteSymbols["__main"].Value != 0) {
-			Throw "Main is not first function in compiled code, code cannot be packed to AHK mcode"
-		}
+	Pack(FormatAsStringLiteral, pCode, CodeSize, Symbols) {
+
+		; First, compress the actual code bytes
+		CompressionBufferSize := VarSetCapacity(CompressionBuffer, CodeSize * 2, 0)
+		pCompressionBuffer := &CompressionBuffer
+
+		CompressedSize := MClib.LZ.Compress(pCode, CodeSize, pCompressionBuffer, CompressionBufferSize)
 		
-		TextSize := Output.SectionsByName[".text"].FileSize
-		
-		; Calculate the target size of the base64 string buffer
+		; Then, convert the compressed code to Base64
 		if !DllCall("Crypt32\CryptBinaryToString"
-			, "Ptr", pCode       ; const BYTE *pbBinary
-			, "UInt", TextSize     ; DWORD      cbBinary
+			, "Ptr", pCompressionBuffer       ; const BYTE *pbBinary
+			, "UInt", CompressedSize     ; DWORD      cbBinary
 			, "UInt", 0x40000001 ; DWORD      dwFlags = CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF
 			, "Ptr", 0           ; LPWSTR     pszString
 			, "UInt*", Base64Length    ; DWORD      *pcchString
@@ -115,34 +171,93 @@ class MClib {
 		
 		VarSetCapacity(Base64, Base64Length * (1 + A_IsUnicode), 0)
 		
-		; Convert to base64
 		if !DllCall("Crypt32\CryptBinaryToString"
-			, "Ptr", pCode       ; const BYTE *pbBinary
-			, "UInt", TextSize     ; DWORD      cbBinary
+			, "Ptr", pCompressionBuffer       ; const BYTE *pbBinary
+			, "UInt", CompressedSize     ; DWORD      cbBinary
 			, "UInt", 0x40000001 ; DWORD      dwFlags = CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF
 			, "Str", Base64         ; LPWSTR     pszString
 			, "UInt*", Base64Length    ; DWORD      *pcchString
 			, "UInt") ; BOOL
 			throw Exception("Failed to convert to b64")
+
+		; And finally, format our output
 		
-		while StrLen(Base64) {
-			Out .= "`n. """ SubStr(Base64, 1, 120-8) """"
-			Base64 := SubStr(Base64, (120-8)+1)
+		if (FormatAsStringLiteral) {
+			; Format the output as an AHK string literal, which can be dropped directly into a source file
+
+			while StrLen(Base64) {
+				Out .= "`n. """ SubStr(Base64, 1, 120-8) """"
+				Base64 := SubStr(Base64, (120-8)+1)
+			}
+
+			Header := """V0;"
+
+			for SymbolName, SymbolOffset in Symbols {
+				Header .= SymbolName "-" SymbolOffset ","
+			}
+
+			Header .= "__size-" CodeSize
+
+			return Header ";""" Out
 		}
-		
-		return Out
+		else {
+			; Don't format the output, return the string that would result from AHK parsing the string literal returned when `FormatAsStringLiteral` is true
+
+			Header := "V0;"
+
+			for SymbolName, SymbolOffset in Symbols {
+				Header .= SymbolName "-" SymbolOffset ","
+			}
+
+			Header .= "__size-" CodeSize
+
+			return Header ";" Base64
+		}
 	}
 	
-	AHKFromC(Code) {
-		return this.Pack(this.Generic("gcc", Code)*)
+	AHKFromC(Code, FormatAsStringLiteral := true) {
+		return this.Pack(FormatAsStringLiteral, this.Compile("gcc", Code)*)
 	}
 	
-	AHKFromCPP(Code) {
-		return this.Pack(this.Generic("g++", "extern ""C"" {`n" Code "`n}", " -fno-exceptions -fno-rtti")*)
+	AHKFromCPP(Code, FormatAsStringLiteral := true) {
+		return this.Pack(FormatAsStringLiteral, this.Compile("g++", "extern ""C"" {`n" Code "`n}", " -fno-exceptions -fno-rtti")*)
 	}
 
 	FromString(Code) {
+		Parts := StrSplit(Code, ";")
 
+		if (Parts[1] != "V0") {
+			Throw "Unknown MClib packed code format"
+		}
 
+		Symbols := {}
+
+		for k, SymbolEntry in StrSplit(Parts[2], ",") {
+			SymbolEntry := StrSplit(SymbolEntry, "-")
+
+			Symbols[SymbolEntry[1]] := SymbolEntry[2]
+		}
+
+		CodeBase64 := Parts[3]
+
+		DecompressedSize := Symbols.__Size
+
+		if !DllCall("Crypt32\CryptStringToBinary", "Str", CodeBase64, "UInt", 0, "UInt", 1
+			, "UPtr", 0, "UInt*", CompressedSize, "Ptr", 0, "Ptr", 0, "UInt")
+			throw Exception("Failed to parse MCLib b64 to binary")
+		
+		CompressedSize := VarSetCapacity(DecompressionBuffer, CompressedSize, 0)
+		pDecompressionBuffer := &DecompressionBuffer
+
+		if !DllCall("Crypt32\CryptStringToBinary", "Str", CodeBase64, "UInt", 0, "UInt", 1
+			, "Ptr", pDecompressionBuffer, "UInt*", CompressedSize, "Ptr", 0, "Ptr", 0, "UInt")
+			throw Exception("Failed to convert MCLib b64 to binary")
+		
+		if !(pBinary := DllCall("GlobalAlloc", "UInt", 0, "Ptr", DecompressedSize, "Ptr"))
+			throw Exception("Failed to reserve MCLib memory")
+
+		MClib.LZ.Decompress(pDecompressionBuffer, CompressedSize, pBinary, DecompressedSize)
+		
+		return MClib.Load(pBinary, DecompressedSize, Symbols)
 	}
 }

--- a/MCLib.ahk
+++ b/MCLib.ahk
@@ -1,144 +1,114 @@
-﻿
-MCLib_FromC(code)
-{
-	;EnvSet, PATH, C:\Program Files\mingw-w64\x86_64-8.1.0-win32-seh-rt_v6-rev0\mingw64\bin
-	EnvSet, PATH, C:\TDM-GCC-64\bin
-	SetWorkingDir, %A_Desktop%\MCLib
-	FileDelete, test.*
-	
-	fmt := A_PtrSize == 4 ? "pe-i386" : "pe-x86-64"
-	FileOpen("linker", "w").Write("OUTPUT_FORMAT(" fmt ")SECTIONS{.text :{*(.text*)*(.rodata*)*(.rdata*)}}")
-	
-	FileOpen("test.c", "w").Write(code)
-	
-	shell := ComObjCreate("WScript.Shell")
-	exec := shell.Exec("gcc.exe -m" A_PtrSize*8 " -g0 -O3 -c test.c")
-	exec.StdIn.Close()
-	
-	if !exec.StdErr.AtEndOfStream
-		throw Exception(exec.StdErr.ReadAll(),, "Compiler Error")
-	
-	m := A_PtrSize == 4 ? "-m i386pe" : ""
-	if shell.Run("ld.exe " m " -T linker test.o -o test.bin", 0, 1)
-		throw Exception("Failed to link",, "Linker Error")
-	if shell.Run("objcopy.exe -O binary -j .text test.bin test.bin", 0, 1)
-		throw Exception("Failed to extract",, "ObjCopy Error")
-	
-	if !(f := FileOpen("test.bin", "r"))
-		throw Exception("Failed to load bin")
-	
-	;while !f.AtEOF
-	;	hex .= Format("{:02x}", f.ReadUChar())
-	;msgbox, %hex%
-	
-	cbBinary := f.length
-	if !(pBinary := DllCall("GlobalAlloc", "UInt", 0, "Ptr", cbBinary, "Ptr"))
-		throw Exception("Failed to reserve MCLib memory")
-	
-	if !DllCall("VirtualProtect"
-		, "Ptr", pBinary  ; LPVOID lpAddress
-		, "Ptr", cbBinary ; SIZE_T dwSize
-		, "UInt", 0x40    ; DWORD  flNewProtect
-		, "UInt*", op     ; PDWORD lpflOldProtect
-		, "UInt") ; BOOL
-		throw Exception("Failed to mark MCLib memory as executable")
-	
-	f.RawRead(pBinary+0, cbBinary)
-	
-	return pBinary
-}
+﻿#Include %A_ScriptDir%
+#Include SymbolReader.ahk
 
-MCLib_AhkFromC(code)
-{
-	EnvSet, PATH, C:\TDM-GCC-64\bin
-	SetWorkingDir, %A_Desktop%\MCLib
-	FileDelete, test.*
-	
-	; Write the code to a file
-	FileOpen("test.c", "w").Write(code)
-	
-	; Execute GCC to compile the c to an unlinked object file
-	shell := ComObjCreate("WScript.Shell")
-	exec := shell.Exec("gcc.exe -m" A_PtrSize*8 " -g0 -O3 -c test.c")
-	exec.StdIn.Close()
-	
-	if !exec.StdErr.AtEndOfStream
-		throw Exception(exec.StdErr.ReadAll(),, "Compiler Error")
-	
-	; Write the appropriate linker script
-	fmt := A_PtrSize == 4 ? "pe-i386" : "pe-x86-64"
-	FileOpen("linker", "w").Write("OUTPUT_FORMAT(" fmt ")SECTIONS{.text :{*(.text*)*(.rodata*)*(.rdata*)}}")
-	
-	; Run the linker using the linker script
-	m := A_PtrSize == 4 ? "-m i386pe" : ""
-	if shell.Run("ld.exe " m " -T linker test.o -o test.bin", 0, 1)
-		throw Exception("Failed to link",, "Linker Error")
-	
-	; Extract the .text section from the linked binary
-	if shell.Run("objcopy.exe -O binary -j .text test.bin test.bin", 0, 1)
-		throw Exception("Failed to extract",, "ObjCopy Error")
-	
-	; Load the linked binary into buffer `buf`
-	if !(f := FileOpen("test.bin", "r"))
-		throw Exception("Failed to load bin")
-	cbBuf := f.length
-	f.RawRead(buf, cbBuf)
-	
-	; Compress the buffer with LZ compression
-	cbCBuf := VarSetCapacity(CBuf, cbBuf*2, 0)
-	cbCBuf := LZ_Compress(&buf, cbBuf, &CBuf, cbCBuf)
-	
-	; Calculate the target size of the base64 string buffer
-	if !DllCall("Crypt32\CryptBinaryToString"
-		, "Ptr", &CBuf       ; const BYTE *pbBinary
-		, "UInt", cbCBuf     ; DWORD      cbBinary
-		, "UInt", 0x40000001 ; DWORD      dwFlags = CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF
-		, "Ptr", 0           ; LPWSTR     pszString
-		, "UInt*", cchStr    ; DWORD      *pcchString
-		, "UInt") ; BOOL
-		throw Exception("Failed to calculate b64 size")
-	
-	; Allocate that much memory into the buffer `str`
-	VarSetCapacity(str, cchStr*(1+A_IsUnicode), 0)
-	
-	; Convert to base64
-	if !DllCall("Crypt32\CryptBinaryToString"
-		, "Ptr", &CBuf       ; const BYTE *pbBinary
-		, "UInt", cbCBuf     ; DWORD      cbBinary
-		, "UInt", 0x40000001 ; DWORD      dwFlags = CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF
-		, "Str", str         ; LPWSTR     pszString
-		, "UInt*", cchStr    ; DWORD      *pcchString
-		, "UInt") ; BOOL
-		throw Exception("Failed to calculate b64 size")
-	
-	; Format output
-	; out := "MCLib(" cbBuf ", """""
-	while StrLen(str)
-		out .= "`n. """ SubStr(str, 1, 120-8) """", str := SubStr(str, (120-8)+1)
-	; out .= ")"
+SetWorkingDir, %A_ScriptDir%
 
-	return out "`n" cbBuf
-}
+class MClib {
+	Generic(Compiler, Code, ExtraOptions := "") {
+		FileOpen("linker_script", "w").Write("OUTPUT_FORMAT(pe-x86-64)SECTIONS{.text :{*(.text*)*(.rodata*)*(.rdata*)*(.data*)*(.bss*)}}")
+		
+		FileOpen("test.c", "w").Write(code)
+		
+		shell := ComObjCreate("WScript.Shell")
+		exec := shell.Exec("x86_64-w64-mingw32-" Compiler ".exe -m64" ExtraOptions " -ffreestanding -nostdlib -T linker_script test.c")
+		exec.StdIn.Close()
+		
+		if !exec.StdErr.AtEndOfStream
+			Throw Exception(exec.StdErr.ReadAll(),, "Compiler Error")
+		
+		if !(F := FileOpen("a.exe", "r"))
+			Throw Exception("Failed to load output file")
+		
+		Size := F.Length
+		
+		if !(pPE := DllCall("GlobalAlloc", "UInt", 0, "Ptr", Size, "Ptr"))
+			Throw Exception("Failed to reserve MCLib PE memory")
+		
+		F.RawRead(pPE + 0, Size)
+		
+		Reader := new PESymbolReader(pPE, Size)
+		Output := Reader.Read()
+		
+		pCode := pPE + Output.SectionsByName[".text"].FileOffset
 
-MCLib(cbBinary, ByRef b64)
-{
-	if (A_PtrSize != 8 || !A_IsUnicode)
-		throw Exception("AHK U64 only")
-	if !DllCall("Crypt32\CryptStringToBinary", "Str", b64, "UInt", 0, "UInt", 1
-		, "UPtr", 0, "UInt*", cbCBuf, "Ptr", 0, "Ptr", 0, "UInt")
-		throw Exception("Failed to parse MCLib b64 to binary")
-	cbCbuf := VarSetCapacity(CBuf, cbCBuf, 0)
-	if !DllCall("Crypt32\CryptStringToBinary", "Str", b64, "UInt", 0, "UInt", 1
-		, "Ptr", &CBuf, "UInt*", cbCBuf, "Ptr", 0, "Ptr", 0, "UInt")
-		throw Exception("Failed to convert MCLib b64 to binary")
-	if !(pBinary := DllCall("GlobalAlloc", "UInt", 0, "Ptr", cbBinary, "Ptr"))
-		throw Exception("Failed to reserve MCLib memory")
-	if !DllCall("VirtualProtect", "Ptr", pBinary, "Ptr", cbBinary, "UInt", 0x40
-		, "UInt*", op, "UInt")
-		throw Exception("Failed to mark MCLib memory as executable")
-	if (r := DllCall("ntdll\RtlDecompressBuffer", "UShort",  0x102, "Ptr"
-		, pBinary, "UInt", cbBinary, "Ptr", &CBuf, "UInt", cbCBuf, "UInt*"
-		, cbFinal, "UInt"))
-		throw Exception("Error decompressing MCLib",, Format("0x{:08x}", r))
-	return pBinary
+		return [pCode, Output]
+	}
+	
+	Fixup(pCode, Output) {
+		static hKernel32    := DllCall("GetModuleHandle", "Str", "kernel32", "Ptr")
+		static hProcessHeap := DllCall("GetProcessHeap", "Ptr")
+		static HeapAlloc    := DllCall("GetProcAddress", "Ptr", hKernel32, "AStr", "HeapAlloc", "Ptr")
+		static HeapFree     := DllCall("GetProcAddress", "Ptr", hKernel32, "AStr", "HeapFree", "Ptr")
+		
+		OffsetOfhProcessHeap := Output.AbsoluteSymbols["hProcessHeap"].Value
+		OffsetOfHeapAlloc    := Output.AbsoluteSymbols["HeapAlloc"].Value
+		OffsetOfHeapFree     := Output.AbsoluteSymbols["HeapFree"].Value
+		OffsetOfMain         := Output.AbsoluteSymbols["__main"].Value
+		
+		if (OffsetOfhProcessHeap && OffsetOfHeapAlloc && OffsetOfHeapFree) {
+			NumPut(hProcessHeap, pCode + 0, OffsetOfhProcessHeap, "Ptr")
+			NumPut(HeapAlloc   , pCode + 0, OffsetOfHeapAlloc   , "Ptr")
+			NumPut(HeapFree    , pCode + 0, OffsetOfHeapFree    , "Ptr")
+		}
+		
+		TextSize := Output.SectionsByName[".text"].FileSize
+		
+		if !DllCall("VirtualProtect", "Ptr", pCode, "Ptr", TextSize, "UInt", 0x40, "UInt*", OldProtect, "UInt")
+			Throw Exception("Failed to mark MCLib memory as executable")
+		
+		return pCode + OffsetOfMain
+	}
+	
+	FromC(Code) {
+		return this.Fixup(this.Generic("gcc", Code)*)
+	}
+	
+	FromCPP(Code) {
+		return this.Fixup(this.Generic("g++", Code, " -fno-exceptions -fno-rtti")*)
+	}
+	
+	Pack(pCode, Output) {
+		if (Output.AbsoluteSymbols["__main"].Value != 0) {
+			Throw "Main is not first function in compiled code, code cannot be packed to AHK mcode"
+		}
+		
+		TextSize := Output.SectionsByName[".text"].FileSize
+		
+		; Calculate the target size of the base64 string buffer
+		if !DllCall("Crypt32\CryptBinaryToString"
+			, "Ptr", pCode       ; const BYTE *pbBinary
+			, "UInt", TextSize     ; DWORD      cbBinary
+			, "UInt", 0x40000001 ; DWORD      dwFlags = CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF
+			, "Ptr", 0           ; LPWSTR     pszString
+			, "UInt*", Base64Length    ; DWORD      *pcchString
+			, "UInt") ; BOOL
+			throw Exception("Failed to calculate b64 size")
+		
+		VarSetCapacity(Base64, Base64Length * (1 + A_IsUnicode), 0)
+		
+		; Convert to base64
+		if !DllCall("Crypt32\CryptBinaryToString"
+			, "Ptr", pCode       ; const BYTE *pbBinary
+			, "UInt", TextSize     ; DWORD      cbBinary
+			, "UInt", 0x40000001 ; DWORD      dwFlags = CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF
+			, "Str", Base64         ; LPWSTR     pszString
+			, "UInt*", Base64Length    ; DWORD      *pcchString
+			, "UInt") ; BOOL
+			throw Exception("Failed to convert to b64")
+		
+		while StrLen(Base64) {
+			Out .= "`n. """ SubStr(Base64, 1, 120-8) """"
+			Base64 := SubStr(Base64, (120-8)+1)
+		}
+		
+		return Out
+	}
+	
+	AHKFromC(Code) {
+		return this.Pack(this.Generic("gcc", Code)*)
+	}
+	
+	AHKFromCPP(Code) {
+		return this.Pack(this.Generic("g++", Code, " -fno-exceptions -fno-rtti")*)
+	}
 }

--- a/SymbolReader.ahk
+++ b/SymbolReader.ahk
@@ -1,0 +1,98 @@
+class SymbolReaderBase {
+	__New(pFileData, Length) {
+		this.pData := pFileData
+		this.Size := Length
+	}
+	
+	ReadString(Offset, Length := -1) {
+		if (Length > 0) {
+			return StrGet(this.pData + Offset, Length, "UTF-8")
+		}
+		else {
+			return StrGet(this.pData + Offset, "UTF-8")
+		}
+	}
+	
+	__Call(MethodName, Params*) {
+		if (RegexMatch(MethodName, "O)Read(\w+)", Read) && Read[1] != "String") {
+			return NumGet(this.pData + 0, Params[1], Read[1])
+		}
+	}
+}
+
+class PESymbolReader extends SymbolReaderBase {
+	ReadSectionHeader(HeaderOffset) {
+		Result := {}
+		
+		Result.Name            := this.ReadString(HeaderOffset, 8)
+		Result.VirtualSize     :=   this.ReadUInt(HeaderOffset + 8)
+		Result.VirtualAddress  :=   this.ReadUInt(HeaderOffset + 12)
+		Result.FileSize        :=   this.ReadUInt(HeaderOffset + 16)
+		Result.FileOffset      :=   this.ReadUInt(HeaderOffset + 20)
+		Result.Characteristics :=   this.ReadUInt(HeaderOffset + 36)
+		
+		return Result
+	}
+
+	ReadSymbolHeader(SymbolNamesOffset, HeaderOffset) {
+		Result := {}
+		
+		if (this.ReadUInt(HeaderOffset) != 0) {
+			Result.Name := this.ReadString(HeaderOffset, 8)
+		}
+		else {
+			Result.Name := this.ReadString(SymbolNamesOffset + this.ReadUInt(HeaderOffset + 4))
+		}
+		
+		Result.Value          :=   this.ReadUInt(HeaderOffset + 8)
+		Result.SectionIndex   := this.ReadUShort(HeaderOffset + 12)
+		Result.Type           := this.ReadUShort(HeaderOffset + 14)
+		Result.StorageClass   :=  this.ReadUChar(HeaderOffset + 16)
+		Result.AuxSymbolCount :=  this.ReadUChar(HeaderOffset + 17)
+		
+		return Result
+	}
+	
+	Read() {
+		static SIZEOF_COFF_HEADER := 20
+		static SIZEOF_SECTION_HEADER := 40
+		static SIZEOF_SYMBOL := 18
+		
+		if (this.ReadUShort(0) != 0x8664) {
+			Throw "Not a valid 64 bit PE object file"
+		}
+		
+		SectionHeaderCount := this.ReadUShort(2)
+		SizeOfOptionalHeader := this.ReadUShort(16)
+		
+		SectionHeaderTableOffset := SIZEOF_COFF_HEADER + SizeOfOptionalHeader
+		
+		Sections := []
+		SectionsByName := {}
+		
+		loop, % SectionHeaderCount {
+			Sections.Push(NextSection := this.ReadSectionHeader(SectionHeaderTableOffset + ((A_Index - 1) * SIZEOF_SECTION_HEADER)))
+			
+			SectionsByName[NextSection.Name] := NextSection
+		}
+		
+		SymbolTableOffset := this.ReadUInt(8)
+		SymbolCount := this.ReadUInt(12)
+		SymbolNamesOffset := SymbolTableOffset + (SymbolCount * SIZEOF_SYMBOL)
+		
+		Symbols := []
+		SymbolsByName := {}
+		
+		SymbolIndex := 0
+		
+		while (SymbolIndex < SymbolCount) {
+			Symbols.Push(NextSymbol := this.ReadSymbolHeader(SymbolNamesOffset, SymbolTableOffset + (SymbolIndex * SIZEOF_SYMBOL)))
+			
+			SymbolsByName[NextSymbol.Name] := NextSymbol
+			
+			SymbolIndex += 1 + NextSymbol.AuxSymbolCount
+		}
+		
+		return {"AbsoluteSymbols": SymbolsByName, "Symbols": Symbols, "Sections": Sections, "SectionsByName": SectionsByName}
+	}
+}

--- a/ahk.h
+++ b/ahk.h
@@ -1,0 +1,40 @@
+#include <stdint.h>
+
+typedef uint64_t size_t;
+
+void* (*HeapAlloc)(uint64_t, uint32_t, size_t);
+void (*HeapFree)(uint64_t, uint32_t, void*);
+
+uint64_t hProcessHeap;
+
+void* malloc(size_t Size) {
+	return HeapAlloc(hProcessHeap, 0x8, Size);
+}
+void free(void* Memory) {
+	HeapFree(hProcessHeap, 0, Memory);
+}
+
+#define MCODE_EXPORT(Name) int __mcode_e_ ## Name () __attribute__((alias(#Name)));
+#define MCODE_EXPORT_INLINE(ReturnType, Name, Parameters) int __mcode_e_ ## Name () __attribute__((alias(#Name))); \
+ReturnType Name Parameters
+
+#ifdef MCODE_LIBRARY
+void __main() {};
+#endif
+
+#ifdef __cplusplus
+
+void* operator new(size_t size) {
+	return HeapAlloc(hProcessHeap, 0x8, size);
+}
+void* operator new[](size_t size) {
+	return HeapAlloc(hProcessHeap, 0x8, size);
+}
+void operator delete(void* Memory) {
+	HeapFree(hProcessHeap, 0, Memory);
+}
+void operator delete[](void* Memory) {
+	HeapFree(hProcessHeap, 0, Memory);
+}
+
+#endif


### PR DESCRIPTION
The biggest change here (besides restructuring the main file) is the addition of [SymbolReader.ahk](https://github.com/CloakerSmoker/MCLib.ahk/blob/main/SymbolReader.ahk), which functions as a combination of the existing `objcopy.exe` invoke, and an extra `objdump.exe` invoke that would be needed to extract symbol information. The core `gcc` command has also been merged with the `ld.exe` invoke.

SymbolReader also enables some much more powerful features, like "exporting" functions by giving them a special name that MCLib can recognize while loading the code. Or "importing" values from AHK through other special symbol names. Currently, "importing" is only implemented as assigning the symbols `HeapAlloc`, `HeapFree`, and `hProcessHeap` to their expected values while loading code. But it could easily be extended.

A [helper C/C++](https://github.com/CloakerSmoker/MCLib.ahk/blob/main/ahk.h) header is also provided, which implements the standard memory allocation functions of C and C++ using the mentioned "imports".

A new text format for compiled code is also added, which retains symbol information allowing for these new features to be used in "packed" code.

I've also added some examples of both C and C++ (with and without memory allocation), along with the new text format.

Unfortunately, this also wipes out any 32-bit support for now. Adding it back shouldn't be too much of a challenge though.